### PR TITLE
Fix for æøå in filenames in word to quarto converter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: statgl
 Title: Statistics Greenland R package
-Version: 0.5.0.9001
+Version: 0.5.0.9002
 Authors@R: 
     person("Emil", "Malta", role = c("aut", "cre"),  email = "emim@stat.gl")
     person("Alexander", "Krabbe", role = c("cre"),  email = "alkr@stat.gl")


### PR DESCRIPTION
Fix for æøå in filenames in word to quarto converter