### PR TITLE
Fix autowidth on statgl_plot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: statgl
 Title: Statistics Greenland R Package
-Version: 0.5.2.9004
+Version: 0.5.2.9005
 Authors@R: c(
     person("Emil", "Malta", , "emim@stat.gl", role = c("aut", "cre")),
     person("Alexander", "Krabbe", , "alkr@stat.gl", role = "aut")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # statgl (development version)
 
+* `statgl_plot()` removes the default Highcharts border around bars and
+  columns (`borderWidth = 0`). The 1 px outline was visually noisy,
+  particularly in dark mode where the contrast made it prominent.
+
 * `statgl_plot()` now reflows the Highcharts chart inside a
   `requestAnimationFrame` callback after render. Fixes charts appearing
   at ~3/4 width when lazy-rendered inside a `shorty` shortcode

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # statgl (development version)
 
+* `statgl_plot()` now reflows the Highcharts chart inside a
+  `requestAnimationFrame` callback after render. Fixes charts appearing
+  at ~3/4 width when lazy-rendered inside a `shorty` shortcode
+  (IntersectionObserver / `<template>` path) until the window is resized.
+
 # statgl 0.5.2.9003
 
 * `statgl_plot()` gains heatmap support via `type = "heatmap"`. Opt-in

--- a/R/statgl_plot.R
+++ b/R/statgl_plot.R
@@ -867,6 +867,11 @@ statgl_plot <- function(
     series_opts$marker <- list(enabled = FALSE)
   }
 
+  # remove bar/column border (looks especially bad in dark mode)
+  if (type %in% c("bar", "column")) {
+    series_opts$borderWidth <- 0
+  }
+
   if (length(series_opts) > 0) {
     chart <- highcharter::hc_plotOptions(chart, series = series_opts)
   }

--- a/R/statgl_plot.R
+++ b/R/statgl_plot.R
@@ -1431,6 +1431,16 @@ statgl_plot <- function(
       if (mql.addEventListener) mql.addEventListener("change", applyOutline);
       else if (mql.addListener) mql.addListener(applyOutline); // Safari fallback
     }
+
+    // Reflow after the browser has calculated layout. When a chart is
+    // lazy-rendered inside a shorty <template> (IntersectionObserver path),
+    // HTMLWidgets.staticRender() fires before the browser runs a layout pass
+    // on the newly-appended content, so Highcharts measures the wrong
+    // container width. requestAnimationFrame defers to after the first paint.
+    requestAnimationFrame(function() {
+      var c = findChart();
+      if (c) { try { c.reflow(); } catch(e) {} }
+    });
   }
   '
   )

--- a/tests/testthat/test-statgl_plot.R
+++ b/tests/testthat/test-statgl_plot.R
@@ -1,0 +1,97 @@
+df_line <- data.frame(
+  time  = 2018:2022,
+  value = c(10, 20, 15, 25, 30)
+)
+
+df_group <- data.frame(
+  time     = rep(2018:2022, 2),
+  value    = c(10, 20, 15, 25, 30, 5, 8, 12, 18, 22),
+  locality = rep(c("Nuuk", "Sisimiut"), each = 5)
+)
+
+# ---------------------------------------------------------------------------
+# Basic output type
+# ---------------------------------------------------------------------------
+
+test_that("statgl_plot() returns a highchart object", {
+  p <- statgl_plot(df_line, x = time, y = value)
+  expect_s3_class(p, "highchart")
+})
+
+# ---------------------------------------------------------------------------
+# onRender reflow
+# ---------------------------------------------------------------------------
+
+test_that("onRender callback contains a requestAnimationFrame reflow", {
+  p <- statgl_plot(df_line, x = time, y = value)
+  js <- p$jsHooks$render[[1]]$code
+  expect_true(grepl("requestAnimationFrame", js, fixed = TRUE))
+  expect_true(grepl("reflow", js, fixed = TRUE))
+})
+
+# ---------------------------------------------------------------------------
+# series_tags
+# ---------------------------------------------------------------------------
+
+test_that("series_tags writes tags onto each series", {
+  p <- statgl_plot(
+    df_group,
+    x = time, y = value, group = locality,
+    series_tags = list(station = "locality")
+  )
+  series <- p$x$hc_opts$series
+  tags   <- vapply(series, function(s) s$tags$station %||% NA_character_, character(1))
+  expect_setequal(tags, c("Nuuk", "Sisimiut"))
+})
+
+test_that("series_tags errors when column is missing", {
+  expect_error(
+    statgl_plot(df_group, x = time, y = value, group = locality,
+                series_tags = list(station = "nonexistent")),
+    "not found"
+  )
+})
+
+# ---------------------------------------------------------------------------
+# legend_position
+# ---------------------------------------------------------------------------
+
+test_that("legend_position = 'none' disables legend", {
+  p <- statgl_plot(df_line, x = time, y = value, legend_position = "none")
+  expect_false(isTRUE(p$x$hc_opts$legend$enabled))
+})
+
+test_that("legend_position = 'right' sets align and layout", {
+  p <- statgl_plot(df_line, x = time, y = value, legend_position = "right")
+  leg <- p$x$hc_opts$legend
+  expect_equal(leg$align, "right")
+  expect_equal(leg$layout, "vertical")
+})
+
+# ---------------------------------------------------------------------------
+# height
+# ---------------------------------------------------------------------------
+
+test_that("height is forwarded to chart options", {
+  p <- statgl_plot(df_line, x = time, y = value, height = 500)
+  expect_equal(p$x$hc_opts$chart$height, 500)
+})
+
+# ---------------------------------------------------------------------------
+# type inference
+# ---------------------------------------------------------------------------
+
+test_that("Date x infers 'line'", {
+  df_dates <- data.frame(
+    time  = as.Date(paste0(2010:2022, "-01-01")),
+    value = seq_len(13)
+  )
+  p <- statgl_plot(df_dates, x = time, y = value)
+  expect_equal(p$x$hc_opts$series[[1]]$type, "line")
+})
+
+test_that("character x infers 'column'", {
+  df_cat <- data.frame(cat = c("A", "B", "C"), value = c(1, 2, 3))
+  p <- statgl_plot(df_cat, x = cat, y = value)
+  expect_equal(p$x$hc_opts$series[[1]]$type, "column")
+})


### PR DESCRIPTION
* `statgl_plot()` removes the default Highcharts border around bars and
  columns (`borderWidth = 0`). The 1 px outline was visually noisy,
  particularly in dark mode where the contrast made it prominent.

* `statgl_plot()` now reflows the Highcharts chart inside a
  `requestAnimationFrame` callback after render. Fixes charts appearing
  at ~3/4 width when lazy-rendered inside a `shorty` shortcode
  (IntersectionObserver / `<template>` path) until the window is resized.